### PR TITLE
JS Load: Remove Animation to Project Cards

### DIFF
--- a/src/components/Works.jsx
+++ b/src/components/Works.jsx
@@ -19,7 +19,7 @@ const ProjectCard = ({
   live_link
 }) => {
   return (
-    <motion.div variants={fadeIn("up", "spring", index * 0.5, 0.75)}>
+    <div>
       <div className='bg-tertiary p-5 rounded-2xl sm:w-[360px] w-full'>
         <div className='relative w-full h-[230px]'>
           <img
@@ -69,7 +69,7 @@ const ProjectCard = ({
           ))}
         </div>
       </div>
-    </motion.div>
+    </div>
   );
 };
 


### PR DESCRIPTION
To reduce load speed, I have removed the animations to project cards using `framer-motion`. This should: 

- [ ] Load the page faster on mobile devices
- [ ] Increase accessibility. 